### PR TITLE
Updated CI to run tests on Ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: ruby
 rvm:
   - 1.9.3
+  - 2.0.0


### PR DESCRIPTION
Updates so that Travis-CI will run against Ruby 2.0.0 as well.
