### PR TITLE
Add line numbers and update tests

### DIFF
--- a/lib/csscss/parser/css.rb
+++ b/lib/csscss/parser/css.rb
@@ -70,7 +70,7 @@ module Csscss
           selector: simple(:selector),
           properties: sequence(:properties)
         }) {
-          Ruleset.new(Selector.from_parser(selector), properties.compact)
+          Ruleset.new(Selector.from_parser(selector), properties.compact, Metadata.from_parser(selector))
         }
 
         rule({

--- a/lib/csscss/types.rb
+++ b/lib/csscss/types.rb
@@ -69,6 +69,12 @@ module Csscss
     end
   end
 
+  class Metadata < Struct.new(:line_number)
+    def self.from_parser(selectors)
+      new(selectors.line_and_column[0])
+    end
+  end
+
   class Selector < Struct.new(:selectors)
     def self.from_parser(selectors)
       new(selectors.to_s.strip)
@@ -87,6 +93,6 @@ module Csscss
     end
   end
 
-  class Ruleset < Struct.new(:selectors, :declarations)
+  class Ruleset < Struct.new(:selectors, :declarations, :metadata)
   end
 end

--- a/test/csscss/parser/css_test.rb
+++ b/test/csscss/parser/css_test.rb
@@ -49,10 +49,10 @@ module Csscss::Parser
         $
 
         trans(css).must_equal([
-          rs(sel("h1, h2"), [dec("display", "none"), dec("position", "relative"), dec("outline", "none")]),
-          rs(sel(".foo"), [dec("display", "none"), dec("width", "1px")]),
-          rs(sel(".bar"), [dec("border", "1px solid black")]),
-          rs(sel(".baz"), [dec("background-color", "black"), dec("background-style", "solid")])
+          rs(sel("h1, h2"), [dec("display", "none"), dec("position", "relative"), dec("outline", "none")], md(2)),
+          rs(sel(".foo"), [dec("display", "none"), dec("width", "1px")], md(3)),
+          rs(sel(".bar"), [dec("border", "1px solid black")], md(4)),
+          rs(sel(".baz"), [dec("background-color", "black"), dec("background-style", "solid")], md(5))
         ])
       end
 
@@ -66,8 +66,8 @@ module Csscss::Parser
         $
 
         trans(css).must_equal([
-          rs(sel(".bar"), [dec("border", "1px solid black /* sdflk */")]),
-          rs(sel(".baz"), [dec("background", "white /* sdflk */")])
+          rs(sel(".bar"), [dec("border", "1px solid black /* sdflk */")], md(5)),
+          rs(sel(".baz"), [dec("background", "white /* sdflk */")], md(6))
         ])
       end
 
@@ -86,7 +86,7 @@ module Csscss::Parser
         $
 
         trans(css).must_equal([
-          rs(sel(".baz"), [dec("background", "white"), dec("border", "1px")])
+          rs(sel(".baz"), [dec("background", "white"), dec("border", "1px")], md(7))
         ])
       end
 
@@ -100,7 +100,7 @@ module Csscss::Parser
         $
 
         trans(css).must_equal([
-          rs(sel(".foo"), [])
+          rs(sel(".foo"), [], md(2))
         ])
       end
 
@@ -123,15 +123,15 @@ module Csscss::Parser
         $
 
         trans(css).must_equal([
-          rs(sel("#foo"), [dec("background-color", "black")]),
-          rs(sel("#bar"), [dec("display", "none")]),
-          rs(sel("h1"), [dec("outline", "1px")])
+          rs(sel("#foo"), [dec("background-color", "black")], md(4)),
+          rs(sel("#bar"), [dec("display", "none")], md(8)),
+          rs(sel("h1"), [dec("outline", "1px")], md(13))
         ])
       end
 
       it "ignores double semicolons" do
         trans("h1 { display:none;;}").must_equal([
-          rs(sel("h1"), [dec("display", "none")])
+          rs(sel("h1"), [dec("display", "none")], md(1))
         ])
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,8 +16,12 @@ module TypeHelpers
     Csscss::Declaration.new(p, v)
   end
 
-  def rs(selectors, decs)
-    Csscss::Ruleset.new(selectors, decs)
+  def rs(selectors, decs, metadata=nil)
+    Csscss::Ruleset.new(selectors, decs, metadata)
+  end
+
+  def md(ln)
+    Csscss::Metadata.new(ln)
   end
 end
 


### PR DESCRIPTION
Augmented the RuleSet struct to contain the metadata about the line number, would be useful to help implement https://github.com/zmoazeni/csscss/issues/39 and pass the data through `redundancy_analyzer.rb`.
