### PR TITLE
Adding summary after csscss is run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+(Unreleased)
+
+* Adds summary of total redundancy
+
 ## 1.3.2 - 6/22/2013 ##
 
 * Fixes attribute parsing bug that includes comments with braces

--- a/lib/csscss/reporter.rb
+++ b/lib/csscss/reporter.rb
@@ -7,9 +7,11 @@ module Csscss
     def report(options = {})
       verbose      = options.fetch(:verbose, false)
       should_color = options.fetch(:color, true)
+      total_redundancy = 0
 
       io = StringIO.new
       @redundancies.each do |selector_groups, declarations|
+        total_redundancy+= 1
         selector_groups = selector_groups.map {|selectors| "{#{maybe_color(selectors, :red, should_color)}}" }
         last_selector = selector_groups.pop
         count = declarations.size
@@ -18,7 +20,7 @@ module Csscss
           declarations.each {|dec| io.puts("  - #{maybe_color(dec, :yellow, should_color)}") }
         end
       end
-
+      io.puts "\n\nTotal redundancy: #{total_redundancy}"
       io.rewind
       io.read
     end

--- a/test/csscss/reporter_test.rb
+++ b/test/csscss/reporter_test.rb
@@ -15,6 +15,9 @@ module Csscss
 {.foo} AND {.bar} share 2 rules
 {h1, h2}, {.foo} AND {.baz} share 1 rule
 {h1, h2} AND {.bar} share 1 rule
+
+
+Total redundancy: 3
 EXPECTED
      reporter.report(color:false).must_equal expected
 
@@ -26,13 +29,21 @@ EXPECTED
   - display: none
 {h1, h2} AND {.bar} share 1 rule
   - position: relative
+
+
+Total redundancy: 3
 EXPECTED
      reporter.report(verbose:true, color:false).must_equal expected
     end
 
     it "prints a new line if there is nothing" do
       reporter = Reporter.new({})
-      reporter.report().must_equal ""
+      expected =<<-EXPECTED
+
+
+Total redundancy: 0
+EXPECTED
+      reporter.report().must_equal expected
     end
   end
 end


### PR DESCRIPTION
I've been using csscss for a little bit while refactoring a lot of plain css and I noticed it wasn't easy to see if changes made were reducing the total amount of redundancy. 

So I added a counter to the end of the output so that a dev can quickly see if what they changed actually made an impact.
